### PR TITLE
Cleanup TmpDir

### DIFF
--- a/src/main/java/com/prezi/logbox/executor/HadoopExecutor.java
+++ b/src/main/java/com/prezi/logbox/executor/HadoopExecutor.java
@@ -57,7 +57,7 @@ public class HadoopExecutor extends Configured implements Executor
             }
         }
 
-        //fileSystem.delete(new Path(executionContext.getTemporalDirectory()), true);
+        fileSystem.delete(new Path(executionContext.getTemporalDirectory()), true);
 
         return exitCode;
     }


### PR DESCRIPTION
Cleanup of TmpDir was _temporarily_ commented out to be able to debug the "Unicode strange chars issue". In the meantime /mnt/tmp got really huge (currently 186k entries), which is not good (we don't want to hit a hard limit on files/dir). **Let's put back the cleanup and only comment it out again, if needed.**

Plus delete stuff older than 7 days (?):
`find /mnt/tmp -mtime +7 -delete`
